### PR TITLE
visualized breadth first search

### DIFF
--- a/src/algorithms/searches/breadthFirst.ts
+++ b/src/algorithms/searches/breadthFirst.ts
@@ -1,0 +1,40 @@
+import {
+  BSResult,
+  ReturnOfCreateNode,
+} from "@/components/searchAlgos/BreadthFirst";
+
+export const breadthFirstSearch = (
+  node: ReturnOfCreateNode,
+  numToFind: number
+): BSResult[] => {
+  if (!node) {
+    return [];
+  }
+
+  const queue = [node];
+  const result: BSResult[] = [];
+
+  while (queue.length) {
+    // remove last node from stack
+    const current = queue.shift();
+    // check if equal to numToFind
+    if (current?.value === numToFind) {
+      result.push({ value: current.value, found: true });
+      return result;
+    }
+    // else push value and check children
+    result.push({ value: current?.value, found: false });
+
+    // if node has left child, push child to stack
+    if (current?.left) {
+      queue.push(current.left);
+    }
+
+    // if node has right child, push child to stack
+    if (current?.right) {
+      queue.push(current.right);
+    }
+  }
+
+  return result;
+};

--- a/src/components/searchAlgos/BreadthFirst.tsx
+++ b/src/components/searchAlgos/BreadthFirst.tsx
@@ -1,7 +1,174 @@
-import React from "react";
+import { breadthFirstSearch } from "@/algorithms/searches/breadthFirst";
+import React, { useEffect, useState } from "react";
+
+// define types
+export type ReturnOfCreateNode = {
+  value: number;
+  left?: ReturnOfCreateNode;
+  right?: ReturnOfCreateNode;
+};
+
+export type BSResult = {
+  value: number | undefined;
+  found: boolean;
+};
+
+// define constant for display
+const dataTree = [1, 2, 4, 5, 3, 6, 7];
+
+const defaultBSResult = [
+  {
+    value: 0,
+    found: false,
+  },
+  {
+    value: 1,
+    found: false,
+  },
+  {
+    value: 2,
+    found: false,
+  },
+  {
+    value: 3,
+    found: false,
+  },
+  {
+    value: 4,
+    found: false,
+  },
+  {
+    value: 5,
+    found: false,
+  },
+  {
+    value: 6,
+    found: false,
+  },
+];
+
+// build tree function
+function createNode(
+  value: number,
+  left?: ReturnOfCreateNode,
+  right?: ReturnOfCreateNode
+) {
+  return { value, left, right };
+}
+
+// constant for function
+const tree = createNode(
+  1,
+  createNode(2, createNode(4), createNode(5)),
+  createNode(3, createNode(6), createNode(7))
+);
 
 const BreadthFirst = () => {
-  return <div>BreadthFirst</div>;
+  const [counter, setCounter] = useState<number>(0);
+  const [bsResult, setBSResult] = useState<BSResult[]>(defaultBSResult);
+
+  useEffect(() => {
+    const result: BSResult[] = breadthFirstSearch(tree, 6);
+
+    setBSResult(result);
+  }, []);
+
+  useEffect(() => {
+    if (counter < bsResult?.length - 1) {
+      setTimeout(() => setCounter(counter + 1), 1000);
+    }
+  }, [counter]);
+
+  return (
+    <div className="flex flex-col items-center justify-evenly w-full h-full">
+      <div className="flex flex-col items-center text-lg">
+        {bsResult[counter].value === dataTree[0] ? (
+          <div className="font-bold border-solid border-red-500 border-2">
+            {dataTree[0]}
+          </div>
+        ) : (
+          dataTree[0]
+        )}
+        <div className="flex flex-row gap-6">
+          <div>/</div>
+          <div>\</div>
+        </div>
+        <div className="flex flex-row gap-10">
+          <div>
+            {bsResult[counter].value === dataTree[1] ? (
+              <div className="font-bold border-solid border-red-500 border-2">
+                {dataTree[1]}
+              </div>
+            ) : (
+              dataTree[1]
+            )}
+          </div>
+          <div>
+            {bsResult[counter].value === dataTree[4] ? (
+              <div className="font-bold border-solid border-red-500 border-2">
+                {dataTree[4]}
+              </div>
+            ) : (
+              dataTree[4]
+            )}
+          </div>
+        </div>
+        <div className="flex flex-row gap-5">
+          <div>/</div>
+          <div>\</div>
+          <div>/</div>
+          <div>\</div>
+        </div>
+        <div className="flex flex-row gap-5">
+          <div>
+            {bsResult[counter].value === dataTree[2] ? (
+              <div className="font-bold border-solid border-red-500 border-2">
+                {dataTree[2]}
+              </div>
+            ) : (
+              dataTree[2]
+            )}
+          </div>
+          <div>
+            {bsResult[counter].value === dataTree[3] ? (
+              <div className="font-bold border-solid border-red-500 border-2">
+                {dataTree[3]}
+              </div>
+            ) : (
+              dataTree[3]
+            )}
+          </div>
+          <div>
+            {bsResult[counter].value === dataTree[5] ? (
+              <div className="font-bold border-solid border-green-500 border-2">
+                {dataTree[5]}
+              </div>
+            ) : (
+              dataTree[5]
+            )}
+          </div>
+          <div>
+            {bsResult[counter].value === dataTree[6] ? (
+              <div className="font-bold border-solid border-red-500 border-2">
+                {dataTree[6]}
+              </div>
+            ) : (
+              dataTree[6]
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-row gap-6">
+        <div className="flex flex-col items-center gap-1">
+          <div className="border-b-2 border-black">Number to Find</div>
+          <div className="text-xl font-bold">6</div>
+        </div>
+        <button className="btn" onClick={() => setCounter(0)}>
+          Again
+        </button>
+      </div>
+    </div>
+  );
 };
 
 export default BreadthFirst;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 525b09fee07ff593e67f6eb6b394a4c90c4b9a72  | 
|--------|--------|

### Summary:
Added BFS algorithm and React component to visualize it, highlighting nodes as they are visited.

**Key points**:
- Added `breadthFirstSearch` function in `src/algorithms/searches/breadthFirst.ts` to perform BFS on a binary tree.
- Created `BreadthFirst` React component in `src/components/searchAlgos/BreadthFirst.tsx` to visualize BFS.
- `BreadthFirst` component uses `useEffect` to run BFS and update state for visualization.
- Nodes are highlighted in the visualization as they are visited.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->